### PR TITLE
Add missing theme outlets

### DIFF
--- a/index.html
+++ b/index.html
@@ -453,9 +453,59 @@
       <h2 class="section-title"><span class="en">Theme Outlets</span><span class="zh">主题门店</span></h2>
       <p class="section-subtitle"><span class="en">Discover our cute stores across Singapore.</span><span class="zh">探索我们在新加坡各地的可爱门店。</span></p>
       <div class="theme-grid">
-        <div class="theme-card"><div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_Gift_Store_Chinatown.png" alt="牛车水总店" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=牛车水总店';"></div><div class="card-content"><h3 class="card-title"><span class="zh">Sinnkawa礼品店 - 牛车水总店</span><span class="en">Sinnkawa Gift Store - Chinatown</span></h3><p class="card-desc"><span class="zh">新加坡牛车水大街，主门店，红色灯笼特色。</span><span class="en">Main outlet at Chinatown, featuring red lanterns.</span></p><div class="card-actions"><a class="visit-btn" href="https://maps.app.goo.gl/AuDRqswjxYYgBVFg8" target="_blank"><span class="zh">带我去</span><span class="en">Take me there</span><span class="icon"><i class="fas fa-map-marker-alt"></i></span></a></div></div></div>
-        <div class="theme-card"><div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_Gift_Store_68_BW_Theme..png" alt="黑白主题店" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=黑白主题店';"></div><div class="card-content"><h3 class="card-title"><span class="zh">Sinnkawa礼品店 - 黑白主题店 (68号)</span><span class="en">Sinnkawa Gift Store - B&W Theme (68)</span></h3><p class="card-desc"><span class="zh">极简黑白色调设计。</span><span class="en">Minimalist black & white design.</span></p><div class="card-actions"><a class="visit-btn" href="https://maps.app.goo.gl/cPchyEaSGGsMjbg99" target="_blank"><span class="zh">带我去</span><span class="en">Take me there</span><span class="icon"><i class="fas fa-map-marker-alt"></i></span></a></div></div></div>
-        <div class="theme-card"><div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_43_Haji_Lane_Megastore_Experience_Zone..png" alt="旗舰体验店" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=旗舰体验店';"></div><div class="card-content"><h3 class="card-title"><span class="zh">Sinnkawa旗舰体验店 (43号)</span><span class="en">Sinnkawa Megastore & Experience Zone (43)</span></h3><p class="card-desc"><span class="zh">宽敞空间，互动体验区，蓝色主题。</span><span class="en">Wide space, interactive zone, blue theme.</span></p><div class="card-actions"></div></div></div>
+        <div class="theme-card">
+          <div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_Gift_Store_Chinatown.png" alt="牛车水总店" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=牛车水总店';"></div>
+          <div class="card-content">
+            <h3 class="card-title"><span class="zh">Sinnkawa礼品店 - 牛车水总店</span><span class="en">Sinnkawa Gift Store - Chinatown</span></h3>
+            <p class="card-desc"><span class="zh">新加坡牛车水大街，主门店，红色灯笼特色。</span><span class="en">Main outlet at Chinatown, featuring red lanterns.</span></p>
+            <div class="card-actions"><a class="visit-btn" href="https://maps.app.goo.gl/AuDRqswjxYYgBVFg8" target="_blank"><span class="zh">带我去</span><span class="en">Take me there</span><span class="icon"><i class="fas fa-map-marker-alt"></i></span></a></div>
+          </div>
+        </div>
+
+        <div class="theme-card">
+          <div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_Gift_Store_22_Haji_Lane.png" alt="哈芝巷22号" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=哈芝巷22号';"></div>
+          <div class="card-content">
+            <h3 class="card-title"><span class="zh">Sinnkawa礼品店 - 哈芝巷22号 (红黄)</span><span class="en">Sinnkawa Gift Store - 22 Haji Lane</span></h3>
+            <p class="card-desc"><span class="zh">涂鸦墙背景，潮玩元素。</span><span class="en">Graffiti wall background, trendy toys.</span></p>
+            <div class="card-actions"><a class="visit-btn" href="https://maps.app.goo.gl/NgZPfmMp2egFZhAQ7" target="_blank"><span class="zh">带我去</span><span class="en">Take me there</span><span class="icon"><i class="fas fa-map-marker-alt"></i></span></a></div>
+          </div>
+        </div>
+
+        <div class="theme-card">
+          <div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_Gift_Store_68_BW_Theme..png" alt="黑白主题店" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=黑白主题店';"></div>
+          <div class="card-content">
+            <h3 class="card-title"><span class="zh">Sinnkawa礼品店 - 黑白主题店 (68号)</span><span class="en">Sinnkawa Gift Store - B&W Theme (68)</span></h3>
+            <p class="card-desc"><span class="zh">极简黑白色调设计。</span><span class="en">Minimalist black & white design.</span></p>
+            <div class="card-actions"><a class="visit-btn" href="https://maps.app.goo.gl/cPchyEaSGGsMjbg99" target="_blank"><span class="zh">带我去</span><span class="en">Take me there</span><span class="icon"><i class="fas fa-map-marker-alt"></i></span></a></div>
+          </div>
+        </div>
+
+        <div class="theme-card">
+          <div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_43_Haji_Lane_Megastore_Experience_Zone..png" alt="旗舰体验店" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=旗舰体验店';"></div>
+          <div class="card-content">
+            <h3 class="card-title"><span class="zh">Sinnkawa旗舰体验店 (43号)</span><span class="en">Sinnkawa Megastore & Experience Zone (43)</span></h3>
+            <p class="card-desc"><span class="zh">宽敞空间，互动体验区，蓝色主题。</span><span class="en">Wide space, interactive zone, blue theme.</span></p>
+            <div class="card-actions"></div>
+          </div>
+        </div>
+
+        <div class="theme-card">
+          <div class="store-img-wrapper"><img class="store-img" src="Soul_Art_Art_IP_62_Haji.png" alt="Soul Art" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=Soul Art';"></div>
+          <div class="card-content">
+            <h3 class="card-title"><span class="zh">Soul Art - 艺术与IP (62号)</span><span class="en">Soul Art - Art & IP (62 Haji)</span></h3>
+            <p class="card-desc"><span class="zh">插画作品，艺术周边，文艺氛围。</span><span class="en">Artworks, IP products, artistic atmosphere.</span></p>
+            <div class="card-actions"><a class="visit-btn" href="https://maps.app.goo.gl/QHbdCKU81UJwMuX27" target="_blank"><span class="zh">带我去</span><span class="en">Take me there</span><span class="icon"><i class="fas fa-map-marker-alt"></i></span></a></div>
+          </div>
+        </div>
+
+        <div class="theme-card">
+          <div class="store-img-wrapper"><img class="store-img" src="Sinnkawa_THEME_Cafe_Chinatown1.png" alt="主题咖啡厅" onerror="this.onerror=null;this.src='https://placehold.co/400x240/89CFF0/ffffff?text=主题咖啡厅';"></div>
+          <div class="card-content">
+            <h3 class="card-title"><span class="zh">Sinnkawa主题咖啡厅 - 牛车水</span><span class="en">Sinnkawa THEME Café - Chinatown</span></h3>
+            <p class="card-desc"><span class="zh">鱼尾狮造型饮品，卡通主题餐桌。</span><span class="en">Merlion drinks, cartoon-themed tables.</span></p>
+            <div class="card-actions"><a class="visit-btn" href="https://maps.app.goo.gl/AuDRqswjxYYgBVFg8" target="_blank"><span class="zh">带我去</span><span class="en">Take me there</span><span class="icon"><i class="fas fa-map-marker-alt"></i></span></a></div>
+          </div>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- add three missing theme outlet cards to the theme section

## Testing
- `npx --yes htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687ca90edcac832e84ea702739d63eee