### PR TITLE
Remove map link for 43 Haji Lane

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,7 +526,6 @@
           <p class="store-desc"><span class="zh">互动体验区，配备大幅展示和蓝色主题设计。</span>
             <span class="en">Interactive experience zone with large format displays and blue-themed design</span>
           </p>
-          <a href="#" class="store-btn">📍 查看地图</a>
         </div>
 
         <div class="store-card">


### PR DESCRIPTION
## Summary
- remove the map button from the 43 Haji Lane store card

## Testing
- `git diff --color index.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_b_687d73af8c7c832e82a5fd0cdcc58afe